### PR TITLE
chore(deps): bump https://github.com/entando-k8s-infrastructure/entando-k8s-operator-common.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,3 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [entando-k8s-infrastructure/entando-jx-maven-java11](https://github.com/entando-k8s-infrastructure/entando-jx-maven-java11.git) |  | []() | 
 [entando-k8s-infrastructure/entando-k8s-infrastructure-parent](https://github.com/entando-k8s-infrastructure/entando-k8s-infrastructure-parent.git) |  | []() | 
 [entando-k8s-infrastructure/entando-k8s-custom-model](https://github.com/entando-k8s-infrastructure/entando-k8s-custom-model.git) |  | []() | 
+[entando-k8s-infrastructure/entando-k8s-operator-common](https://github.com/entando-k8s-infrastructure/entando-k8s-operator-common.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -17,3 +17,9 @@ dependencies:
   url: https://github.com/entando-k8s-infrastructure/entando-k8s-custom-model.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: entando-k8s-infrastructure
+  repo: entando-k8s-operator-common
+  url: https://github.com/entando-k8s-infrastructure/entando-k8s-operator-common.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/entando-k8s-infrastructure-entando-k8s-operator-common-sr.yaml
+++ b/repositories/templates/entando-k8s-infrastructure-entando-k8s-operator-common-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: entando-k8s-infrastructure
+    provider: github
+    repository: entando-k8s-operator-common
+  name: entando-k8s-infrastructure-entando-k8s-operator-common
+spec:
+  description: Imported application for entando-k8s-infrastructure/entando-k8s-operator-common
+  httpCloneURL: https://github.com/entando-k8s-infrastructure/entando-k8s-operator-common.git
+  org: entando-k8s-infrastructure
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: entando-k8s-operator-common
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/entando-k8s-infrastructure/entando-k8s-operator-common.git


### PR DESCRIPTION
Update [entando-k8s-infrastructure/entando-k8s-operator-common](https://github.com/entando-k8s-infrastructure/entando-k8s-operator-common.git) 

Command run was `jx import --github --org entando-k8s-infrastructure --filter operator-common --verbose --disable-updatebot=true`