### PR TITLE
chore(deps): bump https://github.com/entando-k8s/test.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -34,3 +34,4 @@ Dependency | Sources | Version | Mismatched versions
 [entando-k8s/entando-quarkus-parent](https://github.com/entando-k8s/entando-quarkus-parent.git) |  | []() | 
 [entando-k8s/entando-spring-boot-parent](https://github.com/entando-k8s/entando-spring-boot-parent.git) |  | []() | 
 [entando/entando-cms](https://github.com/entando/entando-cms.git) |  | []() | 
+[entando-k8s/test](https://github.com/entando-k8s/test.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -191,3 +191,9 @@ dependencies:
   url: https://github.com/entando/entando-cms.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: entando-k8s
+  repo: test
+  url: https://github.com/entando-k8s/test.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/entando-k8s-test-sr.yaml
+++ b/repositories/templates/entando-k8s-test-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: entando-k8s
+    provider: github
+    repository: test
+  name: entando-k8s-test
+spec:
+  description: Imported application for entando-k8s/test
+  httpCloneURL: https://github.com/entando-k8s/test.git
+  org: entando-k8s
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: test
+  scheduler:
+    kind: ""
+    name: ampie-scheduler
+  url: https://github.com/entando-k8s/test.git


### PR DESCRIPTION
Update [entando-k8s/test](https://github.com/entando-k8s/test.git) 

Command run was `jx import --scheduler=ampie-scheduler .`