### PR TITLE
chore(deps): bump https://github.com/entando-k8s/test.git 

### DIFF
--- a/repositories/templates/entando-k8s-test-sr.yaml
+++ b/repositories/templates/entando-k8s-test-sr.yaml
@@ -17,5 +17,5 @@ spec:
   repo: test
   scheduler:
     kind: ""
-    name: anoue-scheduler
+    name: ampie-scheduler
   url: https://github.com/entando-k8s/test.git


### PR DESCRIPTION
Update [entando-k8s/test](https://github.com/entando-k8s/test.git) 

Command run was `jx import . --scheduler=ampie-scheduler`