### PR TITLE
chore(deps): bump https://github.com/entando/entando-plugin-jpcontentscheduler.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -43,3 +43,4 @@ Dependency | Sources | Version | Mismatched versions
 [entando/entando-plugin-jpversioning](https://github.com/entando/entando-plugin-jpversioning.git) |  | []() | 
 [entando/entando-plugin-jpseo](https://github.com/entando/entando-plugin-jpseo.git) |  | []() | 
 [entando/entando-plugin-jpmail](https://github.com/entando/entando-plugin-jpmail.git) |  | []() | 
+[entando/entando-plugin-jpcontentscheduler](https://github.com/entando/entando-plugin-jpcontentscheduler.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -245,3 +245,9 @@ dependencies:
   url: https://github.com/entando/entando-plugin-jpmail.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: entando
+  repo: entando-plugin-jpcontentscheduler
+  url: https://github.com/entando/entando-plugin-jpcontentscheduler.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/entando-entando-plugin-jpcontentscheduler-sr.yaml
+++ b/repositories/templates/entando-entando-plugin-jpcontentscheduler-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: entando
+    provider: github
+    repository: entando-plugin-jpcontentscheduler
+  name: entando-entando-plugin-jpcontentscheduler
+spec:
+  description: Imported application for entando/entando-plugin-jpcontentscheduler
+  httpCloneURL: https://github.com/entando/entando-plugin-jpcontentscheduler.git
+  org: entando
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: entando-plugin-jpcontentscheduler
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/entando/entando-plugin-jpcontentscheduler.git


### PR DESCRIPTION
Update [entando/entando-plugin-jpcontentscheduler](https://github.com/entando/entando-plugin-jpcontentscheduler.git) 

Command run was `jx import --org=entando --github=true --filter=jpcont`