### PR TITLE
chore(deps): bump https://github.com/entando/entando-docker-base-images.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -48,3 +48,4 @@ Dependency | Sources | Version | Mismatched versions
 [entando/entando-keycloak-plugin](https://github.com/entando/entando-keycloak-plugin.git) |  | []() | 
 [entando/entando-core-bom](https://github.com/entando/entando-core-bom.git) |  | []() | 
 [entando/entando-spring-boot-parent](https://github.com/entando/entando-spring-boot-parent.git) |  | []() | 
+[entando/entando-docker-base-images](https://github.com/entando/entando-docker-base-images.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -275,3 +275,9 @@ dependencies:
   url: https://github.com/entando/entando-spring-boot-parent.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: entando
+  repo: entando-docker-base-images
+  url: https://github.com/entando/entando-docker-base-images.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/entando-entando-docker-base-images-sr.yaml
+++ b/repositories/templates/entando-entando-docker-base-images-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: entando
+    provider: github
+    repository: entando-docker-base-images
+  name: entando-entando-docker-base-images
+spec:
+  description: Imported application for entando/entando-docker-base-images
+  httpCloneURL: https://github.com/entando/entando-docker-base-images.git
+  org: entando
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: entando-docker-base-images
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/entando/entando-docker-base-images.git


### PR DESCRIPTION
Update [entando/entando-docker-base-images](https://github.com/entando/entando-docker-base-images.git) 

Command run was `jx import --org=entando --filter=docker-base-images --github=true`